### PR TITLE
AS-35 EAD exclude list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The plugin converts ead xml to json object model, which allows import into Archi
 ## Installation
 - Check out this repository
 - Create config.yml file based on config.yml.example
+- Optionally create an exclude list ('exclude_list.txt') based on exclude_list.txt.example
 - Install dependencies via Bundler
 
     ``` shell

--- a/analyze_logs.rb
+++ b/analyze_logs.rb
@@ -44,18 +44,21 @@ def err_resp_for(eadid)
   end
 end
 
+# Create a regexp pattern that accounts for basic globbing in the ingest dir
+ingest_dir_regexp = Regexp.quote($config['ingest_dir']).
+                           gsub('\\*', '[^/]+')
 
 five_hundreds = $ingestlog.
                 lines.
                 grep(/Conversion of.*failed.*code '5\d{2}/).
-                map {|el| (m = el.match(/#{Regexp.quote($config['ingest_dir'])}\/(.*?).xml/)) && m[1]}.
+                map {|el| (m = el.match(/#{ingest_dir_regexp}\/(.*?).xml/)) && m[1]}.
                 map {|el| [el, err_resp_for(el)]}.
                 to_h
 
 four_hundreds = $ingestlog.
                 lines.
                 grep(/Conversion of.*failed.*code '4\d{2}/).
-                map {|el| (m = el.match(/#{Regexp.quote($config['ingest_dir'])}\/(.*?).xml/)) && m[1]}.
+                map {|el| (m = el.match(/#{ingest_dir_regexp}\/(.*?).xml/)) && m[1]}.
                 map {|el| [el, err_resp_for(el)]}.
                 to_h
 
@@ -78,7 +81,7 @@ by_error = {
   $ingestlog.
     lines.
     grep(/Upload of.*failed/).
-    map {|s| [(m = s.match(/#{Regexp.quote($config['ingest_dir'])}\/(.*?).xml/)) && m[1], s[(s.index('failed with error \'') + 19)...-2]]}.
+    map {|s| [(m = s.match(/#{ingest_dir_regexp}\/(.*?).xml/)) && m[1], s[(s.index('failed with error \'') + 19)...-2]]}.
     map {|(k,v)|
     m = v.match(
       /Server error: (?:Problem creating '(?<title>.*?)(?:': )(?<error_text>.*)"\]|(?<error_name>.*?: )(?<error_text>.*)"\])/)

--- a/exclude_list.txt
+++ b/exclude_list.txt
@@ -1,0 +1,113 @@
+# A list of EADs to be excluded from ingest.
+# Do not include filepaths or file extensions
+#   (i.e. NOT "SHC/30025" or "30025.xml")
+# Blank lines and lines beginning with '#' are ignored.
+# ------------------------------------
+
+# Too-granular (AS-35 / AS-147)
+P0031
+P0038
+P0081
+P0082
+P0091
+P0105
+05463
+20491
+40139
+
+# 04007* (SOHP) EADs (AS-35)
+# We'll create an entry for each letter though a few of them are not actually
+# in use.
+04007A
+04007B
+04007C
+04007D
+04007E
+04007F
+04007G
+04007H
+04007I
+04007J
+04007K
+04007L
+04007M
+04007N
+04007O
+04007P
+04007Q
+04007R
+04007S
+04007T
+04007U
+04007V
+04007W
+04007X
+04007Y
+04007Z
+# Some non-standard filenames:
+04007_B
+04007K001
+04007K002
+
+# NPS EADs (AS-35)
+nps34246848
+nps36049591
+nps36049682
+nps36049712
+nps36049736
+nps36049748
+nps3604975x
+nps36049761
+nps36049773
+nps36049785
+nps36049803
+nps36049839
+nps36049852
+nps36049876
+nps36049888
+nps3604989x
+nps36049906
+nps36049918
+nps3604992x
+nps36049931
+nps36049967
+nps36049979
+nps36050003
+nps36050039
+nps36050040
+nps36050052
+nps36050064
+nps36050076
+nps3605009x
+nps36050106
+nps36050362
+nps36050374
+nps36050477
+nps36050556
+nps3605060x
+nps36050611
+nps36050647
+nps36050751
+nps36050775
+nps36050787
+nps36050805
+nps36050817
+nps36050829
+nps36050830
+nps36050854
+nps36050878
+nps3605088x
+nps3605091x
+nps36050933
+nps36050945
+nps36050969
+nps44285425
+nps44401474
+nps78228645
+nps79240574
+nps81788034
+nps82777196
+nps82779570
+nps82925276
+nps82925288
+nps82926621

--- a/exclude_list.txt.example
+++ b/exclude_list.txt.example
@@ -1,0 +1,6 @@
+# A list of EADs to be excluded from ingest.
+# Do not include filepaths or file extensions.
+#   (i.e. NOT "SHC/30025" or "30025.xml")
+# Blank lines and lines beginning with '#' are ignored.
+# ------------------------------------
+01234


### PR DESCRIPTION
- AS-35: Ingest is skipped for EADs appearing on `exclude_list.txt`
  - Exclusion is based solely on filename, not path. (This meets our use cases but would not, say, allow exclusion of `SHC/12345.xml` while allowing `OTHER/12345.xml`)
  - Includes logging of excluded EAD and reporting through `analyze_logs.rb`
- Add a provisional list of EADs to be excluded based on current status of AS-35
- Fix `analyze_logs.rb` issue where regexps fail to match log entries when config settings for ingest_dir uses '*' wildcard

https://jira.lib.unc.edu/browse/AS-35